### PR TITLE
Reverse Expansions

### DIFF
--- a/contractions/__init__.py
+++ b/contractions/__init__.py
@@ -91,10 +91,15 @@ replacers = {
 }
 
 
-def fix(s, leftovers=True, slang=True):
+def fix(s, leftovers=True, slang=True, return_pairs=False):
     ts = replacers[(leftovers, slang)]
-    return ts.replace(s)
+    return ts.replace(s, return_pairs)
 
+def reverse(s, matches):
+    if matches:
+        for cont, exp in matches:
+            s = s.replace(exp, cont)
+    return s
 
 def add(key, value):
     for ts in replacers.values():


### PR DESCRIPTION
Added an argument to fix that allows for the return of the (contraction, expansion) pairs, defaults to False. These pairs can be used by the new reverse function to replace the original contractions.

I came across the need for this functionality while using your package, so I figured I'd see if you cared to add it. The implementation is simple and by default retains the original behavior. If you don't see this as useful I completely understand