### PR TITLE
Not replacing "cause", when it's not valid 

### DIFF
--- a/contractions/data/contractions_dict.json
+++ b/contractions/data/contractions_dict.json
@@ -166,5 +166,16 @@
     "you'll've": "you shall have",
     "you'll": "you will",
     "you'd": "you would",
-    "you'd've": "you would have"
+    "you'd've": "you would have",
+    
+    "to cause": "to cause",
+    "will cause": "will cause",
+    "should cause": "should cause",
+    "would cause": "would cause",
+    "can cause": "can cause",
+    "could cause": "could cause",
+    "must cause": "must cause",
+    "might cause": "might cause",
+    "shall cause": "shall cause",
+    "may cause": "may cause"
  }


### PR DESCRIPTION
Fixes #45 by specifically replacing `to cause` with `to cause` and similar, for every modal verb. Solution suggested by @kootenpv.